### PR TITLE
refactor: simplify dependency retrieval in container and enhance type safety

### DIFF
--- a/specs/container.spec.ts
+++ b/specs/container.spec.ts
@@ -49,7 +49,7 @@ describe('Container', () => {
             container.bind(key as ExtractServiceRegistryKeys<typeof serviceRegistry>).toValue(value);
 
             // Act
-            const result = container.get<string>(serviceRegistry.get(key as ExtractServiceRegistryKeys<typeof serviceRegistry>));
+            const result = container.get(key as ExtractServiceRegistryKeys<typeof serviceRegistry>);
 
             // Assert
             expect(result).toBe(value);
@@ -62,7 +62,7 @@ describe('Container', () => {
             container.bind('SIMPLE_FUNCTION').toFunction(sayHelloWorld);
 
             // Act
-            const sayHello = container.get<SayHelloType>(serviceRegistry.get('SIMPLE_FUNCTION'));
+            const sayHello = container.get('SIMPLE_FUNCTION');
 
             // Assert
             expect(sayHello()).toBe('hello world');
@@ -83,7 +83,7 @@ describe('Container', () => {
                         .toHigherOrderFunction(HigherOrderFunctionWithDependencies, ['DEP1', 'DEP2']);
 
                     // Act
-                    const myService = container.get<MyServiceInterface>(serviceRegistry.get('HIGHER_ORDER_FUNCTION_WITH_DEPENDENCIES'));
+                    const myService = container.get('HIGHER_ORDER_FUNCTION_WITH_DEPENDENCIES');
 
                     // Assert
                     expect(myService.runTask()).toBe('Executing with dep1: dependency1 and dep2: 42');
@@ -100,7 +100,7 @@ describe('Container', () => {
                         });
 
                     // Act
-                    const myService = container.get<MyServiceInterface>(serviceRegistry.get('MY_SERVICE'));
+                    const myService = container.get('MY_SERVICE');
 
                     // Assert
                     expect(myService.runTask()).toBe('Executing with dep1: dependency1 and dep2: 42');

--- a/specs/examples/DI.ts
+++ b/specs/examples/DI.ts
@@ -1,16 +1,17 @@
 import { ServiceRegistry} from "../../src";
+import { MyServiceInterface } from "./types";
 
 export const serviceRegistry = new ServiceRegistry()
     .define('DEP1').mapTo<string>()
     .define('DEP2').mapTo<number>()
     .define('LOGGER').mapTo()
-    .define('MY_SERVICE').mapTo()
+    .define('MY_SERVICE').mapTo<MyServiceInterface>()
     .define('MY_USE_CASE').mapTo()
-    .define('SIMPLE_FUNCTION').mapTo()
+    .define('SIMPLE_FUNCTION').mapTo<() => void>()
     .define('NOT_REGISTERED_VALUE').mapTo()
     .define('CLASS_WITH_DEPENDENCIES').mapTo()
     .define('CLASS_WITHOUT_DEPENDENCIES').mapTo()
-    .define('HIGHER_ORDER_FUNCTION_WITH_DEPENDENCIES').mapTo()
+    .define('HIGHER_ORDER_FUNCTION_WITH_DEPENDENCIES').mapTo<MyServiceInterface>()
     .define('HIGHER_ORDER_FUNCTION_WITHOUT_DEPENDENCIES').mapTo()
     .define('CURRIED_FUNCTION_WITHOUT_DEPENDENCIES').mapTo()
     .define('CURRIED_FUNCTION_WITH_DEPENDENCIES').mapTo()

--- a/src/container.ts
+++ b/src/container.ts
@@ -52,7 +52,8 @@ export function createContainer<Services extends Record<string, unknown> = {}>(
 
     const endCircularDependencyDetection = () => resolutionStack.pop();
 
-    const get = <T>(dependencyKey: DependencyKey): T => {
+    const get = <T>(dependency: DependencyKeyType<Services>): T => {
+        const dependencyKey = serviceRegistry.get(dependency);
         if (isCircularDependency(dependencyKey)) {
             const cycle = buildCycleOf(dependencyKey);
             throw new Error(`Circular dependency detected: ${cycle}`);
@@ -99,7 +100,7 @@ export function createContainer<Services extends Record<string, unknown> = {}>(
     };
 
     const resolveDependency = (depKey: DependencyKey): unknown => {
-        return get(depKey);
+        return get(depKey as DependencyKeyType<Services>);
     };
 
     const runInScope = <T>(callback: () => T): T => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ interface Bindable<Services extends Record<string, unknown> = {}> {
 export interface Container<Services extends Record<string, unknown> = {}> extends Bindable<Services>  {
     load(moduleKey: ModuleKey, module: Module<Services>): void;
 
-    get<T>(key: DependencyKey): T;
+    get<Key extends DependencyKeyType<Services>>(key: Key): Services[Key];
 
     unload(key: ModuleKey): void;
 


### PR DESCRIPTION
Before

```ts
 const myService = container.get<MyServiceInterface>(serviceRegistry.get('HIGHER_ORDER_FUNCTION_WITH_DEPENDENCIES'));
```

After
```ts
 const myService = container.get('HIGHER_ORDER_FUNCTION_WITH_DEPENDENCIES');
```
